### PR TITLE
Update ruby vagrantfile to work

### DIFF
--- a/ruby/Vagrantfile
+++ b/ruby/Vagrantfile
@@ -20,6 +20,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell, :inline => "apt-get install -q -y g++ make git curl vim"
 
     # Lang
+    config.vm.provision :shell, :inline => "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
     config.vm.provision :shell, :inline => "curl -L https://get.rvm.io | bash -s stable"
     config.vm.provision :shell, :inline => "rvm install #{version} --latest-binary --autolibs=enabled && rvm --fuzzy alias create default #{version}"
 

--- a/ruby/Vagrantfile
+++ b/ruby/Vagrantfile
@@ -22,6 +22,6 @@ Vagrant.configure("2") do |config|
     # Lang
     config.vm.provision :shell, :inline => "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
     config.vm.provision :shell, :inline => "curl -L https://get.rvm.io | bash -s stable"
-    config.vm.provision :shell, :inline => "rvm install #{version} --latest-binary --autolibs=enabled && rvm --fuzzy alias create default #{version}"
+    config.vm.provision :shell, :inline => "rvm install #{version} --autolibs=enabled && rvm --fuzzy alias create default #{version}"
 
 end


### PR DESCRIPTION
The ruby VagrantFile currently has two issues which this will correct: 

1) installing rvm validates the download against a gpg key. If that key isn't present, the download will fail. So add the key to gpg before installing rvm

2) rvm can't find a binary for 2.2.0 for this image so telling it to use a binary will fail. remove the --latest-binary flag to allow rvm to build 2.2.0. 
